### PR TITLE
Add session-based authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-session": "^1.17.3"
   }
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>Dashboard</title>
+    <link rel="stylesheet" href="style.css"/>
+  </head>
+  <body>
+    <h1>Dashboard</h1>
+    <p>Bem-vindo, admin!</p>
+  </body>
+</html>

--- a/public/login.html
+++ b/public/login.html
@@ -13,16 +13,16 @@
       <button type="submit">Entrar</button>
     </form>
     <script>
-      document.getElementById('login-form').addEventListener('submit', async e => {
+      document.getElementById('login-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const user = document.getElementById('user').value;
         const pass = document.getElementById('pass').value;
         const res = await fetch('/login', {
-          method:'POST',
-          headers:{'Content-Type':'application/json'},
-          body:JSON.stringify({user,pass})
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user, pass })
         });
-        if(res.ok) alert('Logado com sucesso!');
+        if (res.ok) window.location.href = '/dashboard.html';
         else alert('Usuário ou senha inválidos.');
       });
     </script>

--- a/server/server.js
+++ b/server/server.js
@@ -1,16 +1,32 @@
 const express = require('express');
 const path = require('path');
+const session = require('express-session');
 
 const app = express();
 app.use(express.json());
+app.use(session({
+  secret: 'uma-chave-secreta',
+  resave: false,
+  saveUninitialized: false
+}));
 app.use(express.static(path.join(__dirname, '..', 'public')));
+
+function checkAuth(req, res, next) {
+  if (req.session && req.session.user) return next();
+  return res.redirect('/login.html');
+}
 
 app.post('/login', (req, res) => {
   const { user, pass } = req.body || {};
   if (user === 'admin' && pass === '1234') {
+    req.session.user = user;
     return res.sendStatus(200);
   }
   res.sendStatus(401);
+});
+
+app.get('/dashboard.html', checkAuth, (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'dashboard.html'));
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- enable express-session and add authentication middleware
- create protected `/dashboard.html` page
- redirect to dashboard after successful login
- document express-session dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ed482c64883328a645bf17564eeca