### PR TITLE
Add SESSION_SECRET env var support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SESSION_SECRET=change-this-secret

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ npm start
 
 The server will run on port 3000 unless the `PORT` environment variable is set.
 
+The session middleware uses `SESSION_SECRET` to sign cookies. In development
+you can rely on the default `change-this-secret` or set your own value.
+
 ## Credentials
 
 The sample login uses the following credentials:

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const session = require('express-session');
 const app = express();
 app.use(express.json());
 app.use(session({
-  secret: 'uma-chave-secreta',
+  secret: process.env.SESSION_SECRET || 'change-this-secret',
   resave: false,
   saveUninitialized: false
 }));


### PR DESCRIPTION
## Summary
- fetch session secret from `SESSION_SECRET` environment variable with a fallback
- document `SESSION_SECRET` in README
- provide `.env.example` for local setup

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870085357688332ba641cc87cc7d5ca